### PR TITLE
fix: output popup options as separate array elements

### DIFF
--- a/tpad.tmux
+++ b/tpad.tmux
@@ -188,7 +188,10 @@ build_popup_options() {
     else
       val="$(get_config "$instance" "${opt_map[$opt]}")"
     fi
-    [[ -n "$val" ]] && echo "-${opt}" "${val}"
+    if [[ -n "$val" ]]; then
+      echo "-${opt}"
+      echo "${val}"
+    fi
   done
 }
 


### PR DESCRIPTION
The build_popup_options function was echoing flag and value on the same line (e.g., "-T title value"). When read into the popup_opts array, each line became a single element, causing tmux display-popup to receive malformed arguments like "-T title value" instead of separate "-T" and "title value" arguments. This caused the popup to fail silently.

Fix by outputting each flag and value on separate lines so they become separate array elements.