### PR TITLE
Allow specifying binding table with mouse event auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ TPad sessions are configured using tmux options in the format: `@tpad-<session_n
 
 ### Behavior Options
 
-| Option  | Default | Description                                           |
-| ------- | ------- | ----------------------------------------------------- |
-| dir     | $HOME   | Working directory for the session                     |
-| cmd     |         | Command to execute when popup opens                   |
-| prefix  |         | Custom tmux prefix for the session                    |
-| env     |         | Additional environment variables                      |
-| opts    |         | Session-specific tmux options (semicolon-separated)   |
-| per-dir | false   | Create separate sessions per git repository/directory |
+| Option  | Default | Description                                                               |
+| ------- | ------- | ------------------------------------------------------------------------- |
+| cmd     |         | Command to execute when popup opens                                       |
+| dir     | $HOME   | Working directory for the session                                         |
+| env     |         | Additional environment variables                                          |
+| opts    |         | Session-specific tmux options (semicolon-separated)                       |
+| per-dir | false   | Create separate sessions per git repository/directory                     |
+| prefix  |         | Custom tmux prefix for the session                                        |
+| table   |         | Key table for the binding (e.g., `root`). Auto-detected for mouse events. |
 
 ## Example Configuration
 
@@ -96,13 +97,20 @@ set -g @tpad-tasks-width       "40%"
 set -g @tpad-tasks-pos_x       "right"
 set -g @tpad-tasks-pos_y       "bottom"
 set -g @tpad-tasks-cmd         "taskwarrior-tui"
+
+# Right-click to open a scratchpad (table auto-detected as root for mouse events)
+set -g @tpad-scratch-bind      "MouseDown3Pane"
+
+# Keyboard shortcut without prefix key (explicit root table)
+set -g @tpad-quick-bind        "C-Space"
+set -g @tpad-quick-table       "root"
 ```
 
 ## Usage
 
 1. Configure your popup sessions in `tmux.conf` as shown above
-2. Press your tmux prefix key (default: <kbd>Ctrl</kbd>+<kbd>b</kbd>)
-3. Press the configured key binding to toggle the popup (e.g., <kbd>Ctrl</kbd>+<kbd>g</kbd> for the git session)
+2. Press your tmux prefix key (default: <kbd>Ctrl</kbd>+<kbd>b</kbd>), then press the configured key binding to toggle the popup (e.g., <kbd>Ctrl</kbd>+<kbd>g</kbd> for the git session)
+3. For root-table bindings (`table "root"` or mouse events), no prefix key is needed
 4. The popup will close automatically when the command exits
 
 ### Full-screen mode

--- a/tpad.tmux
+++ b/tpad.tmux
@@ -155,7 +155,21 @@ bind_key() {
   local key="$(get_config "$instance" bind)"
   [[ -z "$key" ]] && return
 
-  tmux bind-key "$key" run-shell "$TPAD_SCRIPT toggle $instance"
+  local table="$(get_config "$instance" table)"
+
+  # Mouse events always require the root table
+  if [[ -z "$table" ]]; then
+    case "$key" in
+      Mouse* | DoubleClick* | TripleClick* | WheelUp* | WheelDown*) table="root" ;;
+    esac
+  fi
+
+  if [[ -n "$table" ]]; then
+    tmux bind-key -T "$table" "$key" run-shell "$TPAD_SCRIPT toggle $instance"
+  else
+    tmux bind-key "$key" run-shell "$TPAD_SCRIPT toggle $instance"
+  fi
+
   tmux bind-key -T "tpad_$instance" "$key" run-shell "$TPAD_SCRIPT toggle $instance"
 }
 


### PR DESCRIPTION
Hi, me again! This time more human, less robot.

I wanted to be able to use tmux-tpad with mouse bindings. So I've add the option of specifying the binding table (to handle the general case of allowing whatever kind of binding people want to do), with automatic handling of mouse events specifically (to keep it simple).

Let me know what you think. If you like the idea but want anything adjusted, just let me know.

Thanks!